### PR TITLE
Set stack CLI default to v1.17.0 in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@ Airbus UTM Platform `stack` CLI
 
 ### macOS/Linux one-liner 
 ```
-curl -sSL https://github.com/altiscope/platform-stack-cli/releases/download/v1.10.0/stack_$(
+curl -sSL https://github.com/altiscope/platform-stack-cli/releases/download/v1.17.0/stack_$(
     bash -c '[[ $OSTYPE == darwin* ]] && echo darwin || echo linux'
   )_amd64 -o stack && chmod a+x stack && sudo mv stack /usr/local/bin/
 ```
 
 ### macOS
 ```
-curl -sSL https://github.com/altiscope/platform-stack-cli/releases/download/v1.10.0/stack_darwin_amd64 -o stack && chmod a+x stack && sudo mv stack /usr/local/bin/
+curl -sSL https://github.com/altiscope/platform-stack-cli/releases/download/v1.17.0/stack_darwin_amd64 -o stack && chmod a+x stack && sudo mv stack /usr/local/bin/
 ```
 
 ### Linux
 ```
-curl -sSL https://github.com/altiscope/platform-stack-cli/releases/download/v1.10.0/stack_linux_amd64 -o stack && chmod a+x stack && sudo mv stack /usr/local/bin/
+curl -sSL https://github.com/altiscope/platform-stack-cli/releases/download/v1.17.0/stack_linux_amd64 -o stack && chmod a+x stack && sudo mv stack /usr/local/bin/
 ```


### PR DESCRIPTION
Set stack CLI default to `v1.17.0` in readme